### PR TITLE
fix: the argument of invoke()

### DIFF
--- a/4-energy-agent-collaborator/4.2_energy_agent_invocation.ipynb
+++ b/4-energy-agent-collaborator/4.2_energy_agent_invocation.ipynb
@@ -436,7 +436,8 @@
     "    \"how can I check if my Sunpower double-X solar panel eletrical consumption is compliant with energy rules?\", \n",
     "    energy_agent_id,\n",
     "    session_id=session_id,\n",
-    "    enable_trace=True\n",
+    "    enable_trace=True,\n",
+    "    multi_agent_names=multi_agent_names\n",
     ")\n",
     "print(\"====================\")\n",
     "print(response)"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
When invoking the multi-agent orchestrator, an error occurs because collaborator information is not passed in argument.