### PR TITLE
Resolve numpy version conflict

### DIFF
--- a/3-peak-load-manager/3_peak_load_manager.ipynb
+++ b/3-peak-load-manager/3_peak_load_manager.ipynb
@@ -77,6 +77,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a60e324",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip uninstall -y numpy\n",
+    "!pip install \"numpy<2.0\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "62eabc96",
    "metadata": {},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Resolve numpy version conflict with sagemaker that requires numpy<2.0.
Related: https://github.com/aws/sagemaker-python-sdk/issues/4882

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
